### PR TITLE
updated linux base and Blast+

### DIFF
--- a/Dockerfiles/RepeatMasker-onbuild/Dockerfile
+++ b/Dockerfiles/RepeatMasker-onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 
 MAINTAINER Rob Syme <rob.syme@gmail.com>
 
@@ -39,7 +39,7 @@ RUN wget ftp://ftp.ncbi.nlm.nih.gov/blast/executables/rmblast/2.2.28/ncbi-rmblas
     rm -rf ncbi-rmblastn    
 
 # Install Blast+
-RUN wget ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.6.0/ncbi-blast-2.6.0+-x64-linux.tar.gz && \
+RUN wget ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.7.1/ncbi-blast-2.7.1+-x64-linux.tar.gz && \
     tar -xzvf ncbi-blast* && \
     find ncbi-blast* -type f -executable -exec mv {} bin \; && \  
     rm -rf ncbi-blast*


### PR DESCRIPTION
I had to update ubuntu base to 16.04 because the build process would otherwise crash while trying to install genometools. 
Also, Blast+ was updated to 2.7.1